### PR TITLE
Change bundle-analyzer to static mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 npm-debug.log
 stats.json
 yarn-error.log
+report.html

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -100,7 +100,10 @@ module.exports = {
       template: "./src/index.html",
       filename: "./index.html"
     }),
-    new BundleAnalyzerPlugin(),
+    new BundleAnalyzerPlugin({
+      analyzerMode: "static",
+      reportFilename: "../report.html"
+    }),
     new MiniCssExtractPlugin({
       filename: '[name].css',
       chunkFilename: '[name].bundle.css'


### PR DESCRIPTION
webpack-bundle-analyzer does not exit when running `npm run build`, because it defaults to server mode. Changing it to static makes sure a report is generated and the command returns.